### PR TITLE
fix chat messages not showing for offline participants

### DIFF
--- a/client/src/ui/Chat/ChatBar.svelte
+++ b/client/src/ui/Chat/ChatBar.svelte
@@ -22,7 +22,12 @@
     if (text.match(/^\s*$/)) {
       dispatch("close");
     } else {
-      worldManager.chat.addMessage({ u: participantId, c: text });
+      worldManager.chat.addMessage({ 
+        u: worldManager.participants.local.identityData.name,
+        c: text,
+        p: participantId,
+        o: worldManager.participants.local.identityData.color
+      });
     }
   }
 

--- a/client/src/ui/Chat/ChatBar.svelte
+++ b/client/src/ui/Chat/ChatBar.svelte
@@ -23,9 +23,9 @@
       dispatch("close");
     } else {
       worldManager.chat.addMessage({ 
-        u: worldManager.participants.local.identityData.name,
+        u: participantId,
         c: text,
-        p: participantId,
+        n: worldManager.participants.local.identityData.name,
         o: worldManager.participants.local.identityData.color
       });
     }

--- a/client/src/ui/Chat/ChatHistory.svelte
+++ b/client/src/ui/Chat/ChatHistory.svelte
@@ -28,10 +28,10 @@
   {:else}
     <r-scrollable>
       {#each $messages as message}
-        {#if message.p === myID}
+        {#if message.u === myID}
           <message class:mine={true}>{@html cleanHtml(message.c)}</message>
         {:else}
-          <Message name={message.u} content={message.c} color={message.o} />
+          <Message name={message.n} content={message.c} color={message.o} />
         {/if}
       {/each}
     </r-scrollable>

--- a/client/src/ui/Chat/ChatHistory.svelte
+++ b/client/src/ui/Chat/ChatHistory.svelte
@@ -28,10 +28,10 @@
   {:else}
     <r-scrollable>
       {#each $messages as message}
-        {#if message.u === myID}
+        {#if message.p === myID}
           <message class:mine={true}>{@html cleanHtml(message.c)}</message>
         {:else}
-          <Message participantId={message.u} content={message.c} />
+          <Message name={message.u} content={message.c} color={message.o} />
         {/if}
       {/each}
     </r-scrollable>

--- a/client/src/ui/Chat/Message.svelte
+++ b/client/src/ui/Chat/Message.svelte
@@ -1,42 +1,18 @@
 <script lang="ts">
-  import { onMount } from "svelte/internal";
-  import { worldManager } from "~/world";
-
-  import type { IdentityData } from "~/types";
   import { cleanHtml } from "~/utils/cleanHtml";
 
-  export let participantId: string;
+  export let name: string;
   export let content: string;
-
-  let identity: IdentityData;
-
-  // Poll for participant data
-  // TODO: Make a more elegant way to send the fact that participant 
-  //       data is ready. Perhaps use worldManager.afterInit(fn)?
-  onMount(() => {
-    let interval = setInterval(() => {
-      const participants = worldManager.participants.participants;
-      if (identity) clearInterval(interval);
-      else if (participants) {
-        const participant = participants.get(participantId);
-        if (participant) identity = participant.identityData;
-      }
-    }, 100);
-    return () => clearInterval(interval);
-  });
+  export let color: string;
 </script>
 
-{#if identity}
-  <message>
-    <id-circle style="background-color:{identity.color}" />
-    <container>
-      <who>{identity.name}</who>
-      <content>{@html cleanHtml(content)}</content>
-    </container>
-  </message>
-{:else}
-  <message>Loading...</message>
-{/if}
+<message>
+  <id-circle style="background-color:{color}" />
+  <container>
+    <who>{@html cleanHtml(name)}</who>
+    <content>{@html cleanHtml(content)}</content>
+  </container>
+</message>
 
 <style>
   message {

--- a/client/src/world/ChatManager.ts
+++ b/client/src/world/ChatManager.ts
@@ -6,8 +6,12 @@ import { chatOpen, unreadCount } from "~/stores/chat";
 export type ChatMessage = {
   // Message ("C"ontent)
   c: string;
-  // Author ("U"ser)
+  // Author ("U"sername)
   u: string;
+  // Participant ("P"articipantId)
+  p: string;
+  // Color (C"o"lor)
+  o: string;
 };
 
 export function getEmojiFromMessage(msg) {

--- a/client/src/world/ChatManager.ts
+++ b/client/src/world/ChatManager.ts
@@ -6,10 +6,10 @@ import { chatOpen, unreadCount } from "~/stores/chat";
 export type ChatMessage = {
   // Message ("C"ontent)
   c: string;
-  // Author ("U"sername)
+  // Author ("U"ser)
   u: string;
-  // Participant ("P"articipantId)
-  p: string;
+  // Name ("N"ame)
+  n: string;
   // Color (C"o"lor)
   o: string;
 };


### PR DESCRIPTION
Previously, chat messages would look up participants before displaying their data.
Since the awareness change, this is no longer functional. 

This pull request stores the username, participant id, and the color of the participant's chat message rather than just the participant id and the contents of the message, removing the need to lookup the identity data of the participant id.