### PR TITLE
QuillJS Base64 Fix

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -41,6 +41,7 @@
     "protoo-client": "^4.0.6",
     "quill": "^1.3.7",
     "quill-cursors": "^3.1.2",
+    "quill-image-uploader": "^1.2.3",
     "real-cancellable-promise": "^1.1.1",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",

--- a/client/package.json
+++ b/client/package.json
@@ -41,7 +41,7 @@
     "protoo-client": "^4.0.6",
     "quill": "^1.3.7",
     "quill-cursors": "^3.1.2",
-    "quill-image-uploader": "^1.2.3",
+    "quill-image-uploader": "github:relm-us/quill-image-uploader",
     "real-cancellable-promise": "^1.1.1",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",

--- a/client/src/ecs/plugins/css3d/document/quill/quillInit.ts
+++ b/client/src/ecs/plugins/css3d/document/quill/quillInit.ts
@@ -2,6 +2,7 @@ import Quill from "quill";
 import QuillCursors from "quill-cursors";
 import ImageUploader from "quill-image-uploader";
 import { QuillBinding } from "y-quill";
+import { config } from "~/config";
 
 import { worldManager } from "~/world";
 
@@ -38,9 +39,21 @@ export function quillInit(
   if (toolbar) {
     // The imageUploader REQUIRES the toolbar module to be active.
     modules.imageUploader = {
-      upload: async (file) => {
-        return "https://cdn.discordapp.com/avatars/746171440159522877/096985bcbfd7c002e61b6dbb1d33e477.webp";
-      }
+      upload: file => new Promise((resolve, reject) => {
+          const formData = new FormData();
+          formData.append("file", file);
+
+          fetch(config.serverUploadUrl, {
+            method: "POST",
+            body: formData,
+          })
+          .then(r => r.json())
+          .then(result => resolve(`${config.serverUrl}/asset/${result.files.png}`))
+          .catch(error => {
+            reject("Upload failed");
+            console.error("Upload failure:", error);
+          });
+      })
     };
   }
   const editor = new Quill(container, {

--- a/client/src/ecs/plugins/css3d/document/quill/quillInit.ts
+++ b/client/src/ecs/plugins/css3d/document/quill/quillInit.ts
@@ -1,5 +1,6 @@
 import Quill from "quill";
 import QuillCursors from "quill-cursors";
+import ImageUploader from "quill-image-uploader";
 import { QuillBinding } from "y-quill";
 
 import { worldManager } from "~/world";
@@ -12,14 +13,15 @@ export const fontSizes = [
 ];
 
 Quill.register("modules/cursors", QuillCursors);
+Quill.register("modules/imageUploader", ImageUploader);
 
 // Allowed fonts. We do not add "Sans Serif" since it is the default.
-let Font = Quill.import("formats/font");
+const Font = Quill.import("formats/font");
 Font.whitelist = ["quicksand", "garamond", "oswald", "squarepeg"];
 Quill.register(Font, true);
 
 // Allowed font sizes.
-var Size = Quill.import("attributors/style/size");
+const Size = Quill.import("attributors/style/size");
 Size.whitelist = fontSizes;
 Quill.register(Size, true);
 
@@ -28,11 +30,21 @@ export function quillInit(
   toolbar,
   { cursors = true, readOnly = false, bounds = container }
 ) {
+  const modules = {
+    cursors,
+    toolbar
+  } as any;
+
+  if (toolbar) {
+    // The imageUploader REQUIRES the toolbar module to be active.
+    modules.imageUploader = {
+      upload: async (file) => {
+        return "https://cdn.discordapp.com/avatars/746171440159522877/096985bcbfd7c002e61b6dbb1d33e477.webp";
+      }
+    };
+  }
   const editor = new Quill(container, {
-    modules: {
-      cursors,
-      toolbar,
-    },
+    modules,
     placeholder: "Start collaborating...",
     theme: "snow", // or 'bubble'
     bounds,

--- a/client/src/y-integration/WorldDoc.ts
+++ b/client/src/y-integration/WorldDoc.ts
@@ -1,4 +1,4 @@
-import { AuthenticationHeaders, yTextToDelta } from "relm-common";
+import type { AuthenticationHeaders } from "relm-common";
 import type { DecoratedECSWorld, WorldDocStatus } from "~/types";
 
 import * as Y from "yjs";

--- a/client/src/y-integration/WorldDoc.ts
+++ b/client/src/y-integration/WorldDoc.ts
@@ -1,4 +1,4 @@
-import type { AuthenticationHeaders } from "relm-common";
+import { AuthenticationHeaders, yTextToDelta } from "relm-common";
 import type { DecoratedECSWorld, WorldDocStatus } from "~/types";
 
 import * as Y from "yjs";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,7 @@ importers:
       protoo-client: ^4.0.6
       quill: ^1.3.7
       quill-cursors: ^3.1.2
+      quill-image-uploader: github:relm-us/quill-image-uploader
       real-cancellable-promise: ^1.1.1
       redux: ^4.0.5
       redux-thunk: ^2.3.0
@@ -122,6 +123,7 @@ importers:
       protoo-client: 4.0.6
       quill: 1.3.7
       quill-cursors: 3.1.2
+      quill-image-uploader: github.com/relm-us/quill-image-uploader/b60dd0693dc5e871946a05631ee29180568bd321_quill@1.3.7
       real-cancellable-promise: 1.1.1
       redux: 4.2.0
       redux-thunk: 2.4.1_redux@4.2.0
@@ -14512,3 +14514,14 @@ packages:
   /zwitch/2.0.2:
     resolution: {integrity: sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA==}
     dev: true
+
+  github.com/relm-us/quill-image-uploader/b60dd0693dc5e871946a05631ee29180568bd321_quill@1.3.7:
+    resolution: {tarball: https://codeload.github.com/relm-us/quill-image-uploader/tar.gz/b60dd0693dc5e871946a05631ee29180568bd321}
+    id: github.com/relm-us/quill-image-uploader/b60dd0693dc5e871946a05631ee29180568bd321
+    name: quill-image-uploader
+    version: 1.2.3
+    peerDependencies:
+      quill: ^1.3.7
+    dependencies:
+      quill: 1.3.7
+    dev: false


### PR DESCRIPTION
This pull request implements the custom `quill-image-uploader` fork to remove the base64 saved in the YDoc. 