### PR TITLE
Fix connection screen not appearing on top

### DIFF
--- a/client/src/ui/ButtonControls/ConnectionButton/SignInWindow.svelte
+++ b/client/src/ui/ButtonControls/ConnectionButton/SignInWindow.svelte
@@ -105,7 +105,7 @@
 
 </script>
 
-<Fullwindow>
+<Fullwindow zIndex={100}>
   <r-background></r-background>
   <r-exit on:click={exitScreen}>
     <img src="/ESC_button.png" style="width: 48px;" alt="Signout" />

--- a/client/src/ui/lib/Fullwindow.svelte
+++ b/client/src/ui/lib/Fullwindow.svelte
@@ -2,13 +2,12 @@
   import { onMount, createEventDispatcher } from "svelte";
 
   export let active = true;
-  export let zIndex = 100;
+  export let zIndex = null;
 
   const dispatch = createEventDispatcher();
 
   let el: HTMLElement;
   let parentEl;
-  let style;
 
   function onClick(event) {
     if (event.target === el) dispatch("close", event.target);
@@ -25,7 +24,6 @@
       // Move back to the original parent element
       parentEl.appendChild(el);
     }
-    style = `z-index: ${zIndex}`;
   }
 
   onMount(() => {
@@ -33,7 +31,7 @@
   });
 </script>
 
-<fullwindow bind:this={el} {style} on:click={onClick}>
+<fullwindow bind:this={el} style="z-index: {zIndex}" on:click={onClick}>
   <slot />
 </fullwindow>
 

--- a/client/src/ui/lib/Fullwindow.svelte
+++ b/client/src/ui/lib/Fullwindow.svelte
@@ -21,12 +21,11 @@
       // "fullwindow" mode can escape absolute/relative positioned
       // elements and take up the whole window.
       document.body.appendChild(el);
-      style = `z-index: ${zIndex}`;
     } else if (!active && el.parentElement !== parentEl) {
       // Move back to the original parent element
       parentEl.appendChild(el);
-      style = null;
     }
+    style = `z-index: ${zIndex}`;
   }
 
   onMount(() => {


### PR DESCRIPTION
- Applied a zIndex to the connection screen
- The z-index of Fullwindow components is always applied regardless of the parent element

From what I have seen, the 2nd change has not affected anything existing.